### PR TITLE
Update Django and django-cors-headers version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Django==1.10
-django-cors-middleware==1.2.0
+Django==1.10.5
+django-cors-middleware==1.3.1
 django-extensions==1.7.1
 djangorestframework==3.4.4
 PyJWT==1.4.2


### PR DESCRIPTION
Update Django version to 1.10.5 and django-cors-headers to 1.3.1 to get rid of the exception 

`mw_instance = middleware(handler)
TypeError: object() takes no parameters
`
on running 
`python manage.py runserver`

Used suggestion from issue   #2 